### PR TITLE
Add directory support and default to abcs/ folder

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,9 @@ import FileList from "@/components/FileList";
 import RepoList, { Repo } from "@/components/RepoList";
 import { getRepertoireContent, getRepoFiles, getUserRepos } from "@/lib/github";
 import Link from "next/link";
+import { FileItem } from "@/types/github";
 
-export default async function Home({ searchParams }: { searchParams: Promise<{ repo?: string; file?: string }> }) {
+export default async function Home({ searchParams }: { searchParams: Promise<{ repo?: string; file?: string; path?: string }> }) {
   const session = await getServerSession(authOptions);
 
   if (!session?.accessToken) {
@@ -33,6 +34,7 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ r
   const params = await searchParams;
   const repoName = params.repo;
   const filePath = params.file;
+  const dirPath = params.path;
 
   if (repoName && filePath) {
     // Editor View
@@ -53,11 +55,29 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ r
     );
   } else if (repoName) {
     // File List View
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const files = (await getRepoFiles(session.accessToken, repoName)) as any[];
+    let currentPath = dirPath;
+    let files: FileItem[] | null = null;
+
+    if (currentPath === undefined) {
+        // Default logic: try 'abcs', fallback to root
+        currentPath = "abcs";
+        files = await getRepoFiles(session.accessToken, repoName, currentPath);
+        if (!files) {
+            currentPath = "";
+            files = await getRepoFiles(session.accessToken, repoName, currentPath);
+        }
+    } else {
+        files = await getRepoFiles(session.accessToken, repoName, currentPath);
+        if (!files) {
+            // If the specified path fails, fallback to root
+            currentPath = "";
+            files = await getRepoFiles(session.accessToken, repoName, currentPath);
+        }
+    }
+
     return (
       <main className="min-h-screen">
-        <FileList files={files} repoName={repoName} />
+        <FileList files={files || []} repoName={repoName} currentPath={currentPath} />
       </main>
     );
   } else {

--- a/components/FileList.tsx
+++ b/components/FileList.tsx
@@ -3,26 +3,22 @@
 import Link from "next/link";
 import React from "react";
 import { signOut } from "next-auth/react";
-
-interface FileItem {
-  name: string;
-  path: string;
-  type: string; // 'file' or 'dir'
-  size: number;
-  download_url: string;
-}
+import { FileItem } from "@/types/github";
 
 interface FileListProps {
   files: FileItem[];
   repoName: string;
+  currentPath: string;
 }
 
-export default function FileList({ files, repoName }: FileListProps) {
+export default function FileList({ files, repoName, currentPath }: FileListProps) {
   // Sort: directories first, then files
   const sortedFiles = [...files].sort((a, b) => {
     if (a.type === b.type) return a.name.localeCompare(b.name);
     return a.type === "dir" ? -1 : 1;
   });
+
+  const parentPath = currentPath.split("/").slice(0, -1).join("/");
 
   return (
     <div className="flex min-h-screen flex-col items-center bg-gray-50 p-8">
@@ -38,6 +34,12 @@ export default function FileList({ files, repoName }: FileListProps) {
               </Link>
               <span>/</span>
               <span>{repoName}</span>
+              {currentPath && (
+                  <>
+                      <span>/</span>
+                      <span>{currentPath}</span>
+                  </>
+              )}
             </div>
           </div>
           <button
@@ -49,6 +51,19 @@ export default function FileList({ files, repoName }: FileListProps) {
         </div>
 
         <ul className="divide-y divide-gray-200">
+          {currentPath && (
+              <li className="hover:bg-gray-50 transition-colors">
+                  <Link
+                      href={`/?repo=${repoName}&path=${parentPath}`}
+                      className="block p-4 pl-6"
+                  >
+                      <div className="flex items-center">
+                          <span className="mr-2 text-gray-500">📁</span>
+                          <span className="text-gray-900 font-medium">..</span>
+                      </div>
+                  </Link>
+              </li>
+          )}
           {sortedFiles.length === 0 ? (
             <li className="p-6 text-center text-gray-500">
               No files found.
@@ -57,9 +72,15 @@ export default function FileList({ files, repoName }: FileListProps) {
             sortedFiles.map((file) => (
               <li key={file.path} className="hover:bg-gray-50 transition-colors">
                 {file.type === "dir" ? (
-                  <div className="block p-4 pl-6 text-gray-400">
-                    <span className="font-bold mr-2">📁</span> {file.name} (Directory support pending)
-                  </div>
+                  <Link
+                      href={`/?repo=${repoName}&path=${file.path}`}
+                      className="block p-4 pl-6"
+                  >
+                      <div className="flex items-center">
+                          <span className="mr-2 text-blue-500">📁</span>
+                          <span className="text-gray-900 font-medium">{file.name}</span>
+                      </div>
+                  </Link>
                 ) : (
                   <Link
                     href={`/?repo=${repoName}&file=${encodeURIComponent(file.path)}`}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "octokit";
+import { FileItem } from "@/types/github";
 
 function encodeBase64(str: string) {
     if (typeof window === 'undefined') {
@@ -30,7 +31,7 @@ export async function getUserRepos(accessToken: string) {
   }
 }
 
-export async function getRepoFiles(accessToken: string, repoName: string, path: string = "") {
+export async function getRepoFiles(accessToken: string, repoName: string, path: string = ""): Promise<FileItem[] | null> {
   const octokit = new Octokit({ auth: accessToken });
   const { data: user } = await octokit.rest.users.getAuthenticated();
   let owner = user.login;
@@ -48,13 +49,15 @@ export async function getRepoFiles(accessToken: string, repoName: string, path: 
     });
 
     if (Array.isArray(response.data)) {
-        return response.data.map((item) => ({
-            name: item.name,
-            path: item.path,
-            type: item.type, // 'file' or 'dir'
-            size: item.size,
-            download_url: item.download_url,
-        }));
+        return response.data
+            .filter((item) => item.type === "dir" || item.name.endsWith(".abc"))
+            .map((item) => ({
+                name: item.name,
+                path: item.path,
+                type: item.type, // 'file' or 'dir'
+                size: item.size,
+                download_url: item.download_url,
+            })) as FileItem[];
     } else {
         // If it's a single file (not a directory), return it as an array
         return [{
@@ -63,11 +66,11 @@ export async function getRepoFiles(accessToken: string, repoName: string, path: 
             type: response.data.type,
             size: response.data.size,
             download_url: response.data.download_url,
-        }];
+        }] as FileItem[];
     }
   } catch (error) {
     console.error("Error fetching repo content:", error);
-    return [];
+    return null;
   }
 }
 

--- a/types/github.ts
+++ b/types/github.ts
@@ -1,0 +1,7 @@
+export interface FileItem {
+  name: string;
+  path: string;
+  type: string; // 'file' or 'dir'
+  size: number;
+  download_url: string;
+}


### PR DESCRIPTION
This PR implements directory support for the file browser.
It defaults to opening the `abcs/` directory in the selected repository. If `abcs/` does not exist, it falls back to the root directory.
It also filters the file list to only show directories and files ending in `.abc`.
A new `FileItem` type is introduced to share the file structure between the API and the UI components.

---
*PR created automatically by Jules for task [17300340030708903479](https://jules.google.com/task/17300340030708903479) started by @matt20013*