### PR TITLE
Synchronize audio playback with tune selection

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -46,9 +46,10 @@ export default function Editor({ initialContent, initialSha, accessToken, repoNa
         setSelectedTuneIndex(0);
       }
     }
-  }, [abc]);
+  }, [abc, selectedTuneIndex]);
 
   useEffect(() => {
+    let isCancelled = false;
     if (typeof window !== "undefined") {
       // Render visual
       const visualObj = abcjs.renderAbc("paper", abc, {
@@ -57,8 +58,8 @@ export default function Editor({ initialContent, initialSha, accessToken, repoNa
       });
 
       // Render audio
-      if (visualObj && visualObj[0] && abcjs.synth.supportsAudio()) {
-        const currentTune = visualObj[0];
+      if (visualObj && visualObj[selectedTuneIndex] && abcjs.synth.supportsAudio()) {
+        const currentTune = visualObj[selectedTuneIndex];
         if (!synthControllerRef.current) {
           synthControllerRef.current = new abcjs.synth.SynthController();
           synthControllerRef.current.load("#audio", null, {
@@ -72,6 +73,7 @@ export default function Editor({ initialContent, initialSha, accessToken, repoNa
 
         const createSynth = new abcjs.synth.CreateSynth();
         createSynth.init({ visualObj: currentTune }).then(() => {
+          if (isCancelled) return;
           if (synthControllerRef.current) {
             synthControllerRef.current.setTune(currentTune, false, {})
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -80,10 +82,18 @@ export default function Editor({ initialContent, initialSha, accessToken, repoNa
         })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .catch((error: any) => {
-          console.warn("Audio problem:", error);
+          if (!isCancelled) {
+            console.warn("Audio problem:", error);
+          }
         });
       }
     }
+    return () => {
+      isCancelled = true;
+      if (synthControllerRef.current) {
+        synthControllerRef.current.pause();
+      }
+    };
   }, [abc, selectedTuneIndex]);
 
   const handleSave = async () => {


### PR DESCRIPTION
The music playback in the ABC editor was always playing the first tune in a file, regardless of which tune was selected in the dropdown. This was because the audio synthesis was hardcoded to use `visualObj[0]`.

I fixed this by:
1. Using `visualObj[selectedTuneIndex]` for the synth controller.
2. Implementing an `isCancelled` flag in the `useEffect` to handle race conditions when switching tunes quickly.
3. Adding a cleanup function to the `useEffect` that calls `synthControllerRef.current.pause()` to stop the old audio immediately when the selection changes.
4. Updating the dependency arrays of the relevant `useEffect` hooks to include `selectedTuneIndex`.

Verified the fix using a Playwright script and a temporary test page, confirming that the visual rendering and audio selection now sync correctly.

Fixes #5

---
*PR created automatically by Jules for task [772269982133623124](https://jules.google.com/task/772269982133623124) started by @matt20013*